### PR TITLE
feat(share): Enable sharing of a monorepo-based library as a singleto…

### DIFF
--- a/libs/native-federation-core/src/lib/config/federation-config.ts
+++ b/libs/native-federation-core/src/lib/config/federation-config.ts
@@ -7,6 +7,7 @@ export interface SharedConfig {
   requiredVersion?: string;
   version?: string;
   includeSecondaries?: boolean;
+  import?: string;
 }
 
 export interface FederationConfig {
@@ -23,6 +24,7 @@ export interface NormalizedSharedConfig {
   requiredVersion: string;
   version?: string;
   includeSecondaries?: boolean;
+  import?: string;
 }
 
 export interface NormalizedFederationConfig {

--- a/libs/native-federation-core/src/lib/config/with-native-federation.ts
+++ b/libs/native-federation-core/src/lib/config/with-native-federation.ts
@@ -49,6 +49,7 @@ function normalizeShared(
           strictVersion: shared[cur].strictVersion ?? false,
           version: shared[cur].version,
           includeSecondaries: shared[cur].includeSecondaries,
+          import: shared[cur].import
         },
       }),
       {}

--- a/libs/native-federation-core/src/lib/utils/package-info.ts
+++ b/libs/native-federation-core/src/lib/utils/package-info.ts
@@ -300,7 +300,15 @@ export function _getPackageInfo(
       esm: true,
     };
   }
-
+  cand = secondaryPgkPath + '.mjs';
+  if (fs.existsSync(cand)) {
+    return {
+      entryPoint: cand,
+      packageName,
+      version,
+      esm,
+    };
+  }
   cand = path.join(secondaryPgkPath, 'index.mjs');
   if (fs.existsSync(cand)) {
     return {

--- a/libs/native-federation-runtime/src/lib/load-remote-module.ts
+++ b/libs/native-federation-runtime/src/lib/load-remote-module.ts
@@ -62,7 +62,7 @@ function getRemoteNameByOptions(options: LoadRemoteModuleOptions) {
     remoteName = getRemoteNameByBaseUrl(baseUrl);
   } else {
     throw new Error(
-      'unexpcted arguments: Please pass remoteName or remoteEntry'
+      'Unexpected arguments: Please pass remoteName or remoteEntry'
     );
   }
 


### PR DESCRIPTION
feat(share): Enable sharing of a monorepo-based library as a singleton across shell and MFEs

- Added import parameters to allow the sharing of a library that is not hosted on npm but resides within the monorepo.
- This change enables the library to be shareable and ensures its services can act as singletons, facilitating shared state management between the shell and micro frontends.